### PR TITLE
apply the language highlighting to all tpl files

### DIFF
--- a/grammars/yaml-gotpl.cson
+++ b/grammars/yaml-gotpl.cson
@@ -1,8 +1,7 @@
 'scopeName': 'source.yaml.gotpl'
 'name': 'YAML (Go Template)'
 'fileTypes': [
-    'yaml.tpl',
-    'yml.tpl'
+    'tpl'
 ]
 'patterns': [
     {


### PR DESCRIPTION
This PR enables the language highlighting for all files with the `tpl` extension. This makes it easier to work with the helm `_helper.tpl` files out of the box.